### PR TITLE
Fixes various 3x3 Altars during worldgen when Calamity is enabled

### DIFF
--- a/Tiles/Altar/GravAltar.cs
+++ b/Tiles/Altar/GravAltar.cs
@@ -1,8 +1,9 @@
-﻿using Microsoft.Xna.Framework;
+﻿using BaseMod;
+using Microsoft.Xna.Framework;
 using Terraria;
+using Terraria.Enums;
 using Terraria.ModLoader;
 using Terraria.ObjectData;
-using BaseMod;
 
 namespace AAMod.Tiles.Altar
 {
@@ -16,6 +17,7 @@ namespace AAMod.Tiles.Altar
             dustType = mod.DustType("DarkmatterDust");
             Main.tileLavaDeath[Type] = false;
             TileObjectData.newTile.CopyFrom(TileObjectData.Style3x3);
+            TileObjectData.newTile.Direction = TileObjectDirection.None;
             TileObjectData.newTile.CoordinateHeights = new int[] { 16, 16, 18 };
             TileObjectData.newTile.CoordinateWidth = 16;
             TileObjectData.newTile.CoordinatePadding = 2;

--- a/Tiles/Altar/StarAltar.cs
+++ b/Tiles/Altar/StarAltar.cs
@@ -1,9 +1,10 @@
-﻿using Microsoft.Xna.Framework;
+﻿using BaseMod;
+using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 using Terraria;
+using Terraria.Enums;
 using Terraria.ModLoader;
 using Terraria.ObjectData;
-using BaseMod;
 
 namespace AAMod.Tiles.Altar
 {
@@ -17,6 +18,7 @@ namespace AAMod.Tiles.Altar
             dustType = mod.DustType("RadiumDust");
             Main.tileLavaDeath[Type] = false;
             TileObjectData.newTile.CopyFrom(TileObjectData.Style3x3);
+            TileObjectData.newTile.Direction = TileObjectDirection.None;
             TileObjectData.newTile.CoordinateHeights = new int[] { 16, 16, 18 };
             TileObjectData.newTile.CoordinateWidth = 16;
             TileObjectData.newTile.CoordinatePadding = 2;

--- a/Tiles/Boss/AcropolisAltar.cs
+++ b/Tiles/Boss/AcropolisAltar.cs
@@ -1,13 +1,14 @@
-﻿using BaseMod;
+﻿using AAMod.NPCs.Bosses.Athena;
+using AAMod.NPCs.Bosses.Athena.Olympian;
+using BaseMod;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 using Terraria;
+using Terraria.Enums;
 using Terraria.ID;
+using Terraria.Localization;
 using Terraria.ModLoader;
 using Terraria.ObjectData;
-using Terraria.Localization;
-using AAMod.NPCs.Bosses.Athena;
-using AAMod.NPCs.Bosses.Athena.Olympian;
 
 namespace AAMod.Tiles.Boss
 {
@@ -21,6 +22,7 @@ namespace AAMod.Tiles.Boss
             dustType = DustID.BlueCrystalShard;
             Main.tileLavaDeath[Type] = false;
             TileObjectData.newTile.CopyFrom(TileObjectData.Style3x3);
+            TileObjectData.newTile.Direction = TileObjectDirection.None;
             TileObjectData.newTile.CoordinateHeights = new int[] { 16, 16, 18 };
             TileObjectData.newTile.CoordinateWidth = 16;
             TileObjectData.newTile.CoordinatePadding = 2;

--- a/Tiles/Boss/AcropolisAltar.cs
+++ b/Tiles/Boss/AcropolisAltar.cs
@@ -21,7 +21,7 @@ namespace AAMod.Tiles.Boss
             dustType = DustID.BlueCrystalShard;
             Main.tileLavaDeath[Type] = false;
             TileObjectData.newTile.CopyFrom(TileObjectData.Style3x3);
-            TileObjectData.newTile.CoordinateHeights = new int[] { 16, 16, 16 };
+            TileObjectData.newTile.CoordinateHeights = new int[] { 16, 16, 18 };
             TileObjectData.newTile.CoordinateWidth = 16;
             TileObjectData.newTile.CoordinatePadding = 2;
             TileObjectData.addTile(Type);

--- a/Tiles/Boss/GreedAltar.cs
+++ b/Tiles/Boss/GreedAltar.cs
@@ -19,7 +19,7 @@ namespace AAMod.Tiles.Boss
             dustType = DustID.Gold;
             Main.tileLavaDeath[Type] = false;
             TileObjectData.newTile.CopyFrom(TileObjectData.Style3x3);
-            TileObjectData.newTile.CoordinateHeights = new int[] { 16, 16, 16 };
+            TileObjectData.newTile.CoordinateHeights = new int[] { 16, 16, 18 };
             TileObjectData.newTile.CoordinateWidth = 16;
             TileObjectData.newTile.CoordinatePadding = 2;
             TileObjectData.addTile(Type);

--- a/Tiles/Boss/GreedAltar.cs
+++ b/Tiles/Boss/GreedAltar.cs
@@ -1,11 +1,12 @@
-﻿using BaseMod;
+﻿using AAMod.NPCs.Bosses.Greed;
+using BaseMod;
 using Microsoft.Xna.Framework;
 using Terraria;
+using Terraria.Enums;
 using Terraria.ID;
+using Terraria.Localization;
 using Terraria.ModLoader;
 using Terraria.ObjectData;
-using Terraria.Localization;
-using AAMod.NPCs.Bosses.Greed;
 
 namespace AAMod.Tiles.Boss
 {
@@ -19,6 +20,7 @@ namespace AAMod.Tiles.Boss
             dustType = DustID.Gold;
             Main.tileLavaDeath[Type] = false;
             TileObjectData.newTile.CopyFrom(TileObjectData.Style3x3);
+            TileObjectData.newTile.Direction = TileObjectDirection.None;
             TileObjectData.newTile.CoordinateHeights = new int[] { 16, 16, 18 };
             TileObjectData.newTile.CoordinateWidth = 16;
             TileObjectData.newTile.CoordinatePadding = 2;

--- a/Tiles/Decoration/AvesInABox.cs
+++ b/Tiles/Decoration/AvesInABox.cs
@@ -13,9 +13,9 @@ namespace AAMod.Tiles.Decoration
 		public override void SetDefaults()
 		{
 			Main.tileFrameImportant[Type] = true;
-            TileObjectData.newTile.AnchorBottom = new AnchorData(AnchorType.SolidTile | AnchorType.SolidWithTop | AnchorType.Table | AnchorType.SolidSide, TileObjectData.newTile.Width, 0);
             TileObjectData.newTile.CopyFrom(TileObjectData.Style3x2);
-			TileObjectData.addTile(Type);
+            TileObjectData.newTile.AnchorBottom = new AnchorData(AnchorType.SolidTile | AnchorType.SolidWithTop | AnchorType.Table | AnchorType.SolidSide, TileObjectData.newTile.Width, 0);
+            TileObjectData.addTile(Type);
 			ModTranslation name = CreateMapEntryName();
 			name.SetDefault("Aves In A Box");
 			AddMapEntry(new Color(100, 200, 100), name);

--- a/Tiles/Furniture/Bogwood/BogwoodLamp.cs
+++ b/Tiles/Furniture/Bogwood/BogwoodLamp.cs
@@ -19,7 +19,7 @@ namespace AAMod.Tiles.Furniture.Bogwood
             Main.tileNoAttach[Type] = true;
             Main.tileWaterDeath[Type] = true;
 
-            TileObjectData.newTile.Width = 1;
+            TileObjectData.newTile.CopyFrom(TileObjectData.Style1xX);
             TileObjectData.newTile.Height = 3;
             TileObjectData.newTile.Origin = new Point16(0, 2);
             TileObjectData.newTile.AnchorBottom = new AnchorData(AnchorType.SolidTile | AnchorType.SolidWithTop | AnchorType.SolidSide, TileObjectData.newTile.Width, 0);
@@ -33,7 +33,6 @@ namespace AAMod.Tiles.Furniture.Bogwood
             };
             TileObjectData.newTile.CoordinateWidth = 16;
             TileObjectData.newTile.CoordinatePadding = 2;
-            TileObjectData.newTile.CopyFrom(TileObjectData.Style1xX);
             TileObjectData.newTile.WaterDeath = true;
             TileObjectData.newTile.WaterPlacement = LiquidPlacement.NotAllowed;
             TileObjectData.newTile.LavaPlacement = LiquidPlacement.NotAllowed;

--- a/Tiles/Furniture/Razewood/RazewoodLamp.cs
+++ b/Tiles/Furniture/Razewood/RazewoodLamp.cs
@@ -19,7 +19,7 @@ namespace AAMod.Tiles.Furniture.Razewood
             Main.tileNoAttach[Type] = true;
             Main.tileWaterDeath[Type] = true;
 
-            TileObjectData.newTile.Width = 1;
+            TileObjectData.newTile.CopyFrom(TileObjectData.Style1xX);
             TileObjectData.newTile.Height = 3;
             TileObjectData.newTile.Origin = new Point16(0, 2);
             TileObjectData.newTile.AnchorBottom = new AnchorData(AnchorType.SolidTile | AnchorType.SolidWithTop | AnchorType.SolidSide, TileObjectData.newTile.Width, 0);
@@ -33,7 +33,6 @@ namespace AAMod.Tiles.Furniture.Razewood
             };
             TileObjectData.newTile.CoordinateWidth = 16;
             TileObjectData.newTile.CoordinatePadding = 2;
-            TileObjectData.newTile.CopyFrom(TileObjectData.Style1xX);
             TileObjectData.newTile.WaterDeath = true;
             TileObjectData.newTile.WaterPlacement = LiquidPlacement.NotAllowed;
             TileObjectData.newTile.LavaPlacement = LiquidPlacement.NotAllowed;


### PR DESCRIPTION
3x3 tiles have placement errors in worldgen when both Calamity and AA are enabled. Similar fixes were applied to Calamity's Fan Corals to work around Sunken Sea crashes.

The underlying problem involves the default 3x3 tile style having a placement direction of "Right" instead of "None".