### PR TITLE
Fixed Shen Trophy's purple sprite being unusable

### DIFF
--- a/Tiles/Trophy/ShenTrophy.cs
+++ b/Tiles/Trophy/ShenTrophy.cs
@@ -15,7 +15,10 @@ namespace AAMod.Tiles.Trophy
 			TileObjectData.newTile.CopyFrom(TileObjectData.Style3x3Wall);
             TileObjectData.newTile.StyleHorizontal = true;
             TileObjectData.newTile.StyleWrapLimit = 36;
+			TileObjectData.newTile.Direction = TileObjectDirection.PlaceLeft;
+			TileObjectData.newAlternate.CopyFrom(TileObjectData.newTile);
             TileObjectData.newAlternate.Direction = TileObjectDirection.PlaceRight;
+			TileObjectData.addAlternate(1);
             TileObjectData.addTile(Type);
             dustType = 7;
 			disableSmartCursor = true;


### PR DESCRIPTION
Shen Trophy wasn't registering its alternate style properly. Fixing this allows its purple sprite to be placed in-game. It may have also been contributing to the Calamity + AA world generation bugs because it wasn't properly cleaning up `TileObjectData.newAlternate`.